### PR TITLE
Fix the alignment of the excuses

### DIFF
--- a/DeveloperExcuses/DeveloperExcusesView.m
+++ b/DeveloperExcuses/DeveloperExcusesView.m
@@ -29,31 +29,6 @@
     return self;
 }
 
-- (void)startAnimation
-{
-    [super startAnimation];
-}
-
-- (void)stopAnimation
-{
-    [super stopAnimation];
-}
-
-- (NSRect) activeScreenRect
-{
-    
-    NSRect screenRect;
-    NSArray *screenArray = [NSScreen screens];
-    NSInteger screenCount = [screenArray count];
-    
-    for (NSInteger i = 0; i < screenCount; i++)
-    {
-        NSScreen *screen = [screenArray objectAtIndex:i];
-        screenRect = [screen visibleFrame];
-    }
-    return screenRect;
-}
-
 - (void)drawRect:(NSRect)rect
 {
     [super drawRect:rect];
@@ -61,7 +36,7 @@
     NSSize s = [self.label.stringValue sizeWithAttributes:@{NSFontAttributeName: self.label.font}];
     CGRect rl = self.label.frame;
     rl.size.height = s.height;
-    rl.origin.y = [self activeScreenRect].size.height/2;
+    rl.origin.y = rect.size.height/2;
     self.label.frame = rl;
     self.label.textColor = [NSColor blackColor];
 


### PR DESCRIPTION
Just use the rect that is passed as argument instead of the `activeScreenRect` which was always the frame from the last screen