### PR TITLE
Fix the alignment of the excuses, again

### DIFF
--- a/DeveloperExcuses/DeveloperExcusesView.swift
+++ b/DeveloperExcuses/DeveloperExcusesView.swift
@@ -57,10 +57,11 @@ class DeveloperExcusesView: ScreenSaverView {
         super.draw(rect)
         
         var newFrame = label.frame
-        let height = (label.stringValue as NSString).size(withAttributes: [NSFontAttributeName: label.font!]).height
-        newFrame.size.height = height;
-        newFrame.origin.y = rect.size.height / 2;
-        label.frame = newFrame;
+        newFrame.origin.x = 0
+        newFrame.origin.y = rect.size.height / 2
+        newFrame.size.width = rect.size.width
+        newFrame.size.height = (label.stringValue as NSString).size(withAttributes: [NSFontAttributeName: label.font!]).height
+        label.frame = newFrame
         
         NSColor.black.setFill()
         NSRectFill(rect)


### PR DESCRIPTION
The `origin.x` and `size.width` properties of `label.frame` were never changed. This caused wrong alignments on my 3-monitor-setup.

Somehow related to #3