### PR TITLE
Add font size preference

### DIFF
--- a/DeveloperExcuses.xcodeproj/project.pbxproj
+++ b/DeveloperExcuses.xcodeproj/project.pbxproj
@@ -25,6 +25,10 @@
 		2A9D0E6817DB87B300DBFFBD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A9D0E6717DB87B300DBFFBD /* Cocoa.framework */; };
 		2A9D0E6A17DB87B300DBFFBD /* ScreenSaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A9D0E6917DB87B300DBFFBD /* ScreenSaver.framework */; };
 		2A9D0E7417DB87B300DBFFBD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2A9D0E7217DB87B300DBFFBD /* InfoPlist.strings */; };
+		3C9050DD2440FD9200542954 /* DeveloperExcusesConfigureSheetWC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9050DB2440FD9100542954 /* DeveloperExcusesConfigureSheetWC.swift */; };
+		3C9050DE2440FD9200542954 /* DeveloperExcusesConfigureSheetWC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3C9050DC2440FD9200542954 /* DeveloperExcusesConfigureSheetWC.xib */; };
+		3C9050DF2440FE4B00542954 /* DeveloperExcusesConfigureSheetWC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9050DB2440FD9100542954 /* DeveloperExcusesConfigureSheetWC.swift */; };
+		3C9050E02440FE4E00542954 /* DeveloperExcusesConfigureSheetWC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3C9050DC2440FD9200542954 /* DeveloperExcusesConfigureSheetWC.xib */; };
 		8117802E1D80A79F00127177 /* thumbnail@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8117802D1D80A79F00127177 /* thumbnail@2x.png */; };
 		811780321D80B5DD00127177 /* thumbnail.png in Resources */ = {isa = PBXBuildFile; fileRef = 811780311D80B5DD00127177 /* thumbnail.png */; };
 /* End PBXBuildFile section */
@@ -64,6 +68,8 @@
 		2A9D0E7117DB87B300DBFFBD /* DeveloperExcuses-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "DeveloperExcuses-Info.plist"; sourceTree = "<group>"; };
 		2A9D0E7317DB87B300DBFFBD /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		2A9D0E7517DB87B300DBFFBD /* DeveloperExcuses-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DeveloperExcuses-Prefix.pch"; sourceTree = "<group>"; };
+		3C9050DB2440FD9100542954 /* DeveloperExcusesConfigureSheetWC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperExcusesConfigureSheetWC.swift; sourceTree = "<group>"; };
+		3C9050DC2440FD9200542954 /* DeveloperExcusesConfigureSheetWC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DeveloperExcusesConfigureSheetWC.xib; sourceTree = "<group>"; };
 		8117802D1D80A79F00127177 /* thumbnail@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "thumbnail@2x.png"; sourceTree = "<group>"; };
 		811780311D80B5DD00127177 /* thumbnail.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = thumbnail.png; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -164,6 +170,8 @@
 				07B5E453218645DF0005E36F /* Extension */,
 				07B5E450218645D50005E36F /* View */,
 				077BC2B01DA22D14007DE060 /* DeveloperExcusesView.swift */,
+				3C9050DB2440FD9100542954 /* DeveloperExcusesConfigureSheetWC.swift */,
+				3C9050DC2440FD9200542954 /* DeveloperExcusesConfigureSheetWC.xib */,
 				2A9D0E7017DB87B300DBFFBD /* Supporting Files */,
 			);
 			path = DeveloperExcuses;
@@ -279,6 +287,7 @@
 			files = (
 				076642F51EE92D6D00FE8619 /* Assets.xcassets in Resources */,
 				076643011EE92E8B00FE8619 /* Main.storyboard in Resources */,
+				3C9050E02440FE4E00542954 /* DeveloperExcusesConfigureSheetWC.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -286,6 +295,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C9050DE2440FD9200542954 /* DeveloperExcusesConfigureSheetWC.xib in Resources */,
 				2A9D0E7417DB87B300DBFFBD /* InfoPlist.strings in Resources */,
 				8117802E1D80A79F00127177 /* thumbnail@2x.png in Resources */,
 				811780321D80B5DD00127177 /* thumbnail.png in Resources */,
@@ -313,6 +323,7 @@
 				07F22F0B23EEE68000F939BF /* TimeInterval+FetchInterval.swift in Sources */,
 				07F22F0923EEE68000F939BF /* UserDefaults+LastLine.swift in Sources */,
 				07F22F0A23EEE68000F939BF /* Date+FetchInterval.swift in Sources */,
+				3C9050DF2440FE4B00542954 /* DeveloperExcusesConfigureSheetWC.swift in Sources */,
 				076642FD1EE92D9500FE8619 /* DeveloperExcusesView.swift in Sources */,
 				076642F11EE92D6D00FE8619 /* AppDelegate.swift in Sources */,
 				07F22F0623EEE67400F939BF /* OnelinerView.swift in Sources */,
@@ -327,6 +338,7 @@
 				077BC2B11DA22D14007DE060 /* DeveloperExcusesView.swift in Sources */,
 				07B5E45B218645DF0005E36F /* UserDefaults+LastLine.swift in Sources */,
 				07B5E45C218645DF0005E36F /* Date+FetchInterval.swift in Sources */,
+				3C9050DD2440FD9200542954 /* DeveloperExcusesConfigureSheetWC.swift in Sources */,
 				07B5E459218645DF0005E36F /* String+Constants.swift in Sources */,
 				07B5E45D218645DF0005E36F /* TimeInterval+FetchInterval.swift in Sources */,
 			);

--- a/DeveloperExcuses/DeveloperExcusesConfigureSheetWC.swift
+++ b/DeveloperExcuses/DeveloperExcusesConfigureSheetWC.swift
@@ -1,0 +1,20 @@
+import Cocoa
+import ScreenSaver
+
+class DeveloperExcusesConfigureSheetWC: NSWindowController {
+    override func windowDidLoad() {
+        super.windowDidLoad()
+    }
+    
+    @IBAction func endSheet(_ sender: Any?) {
+        if let window = window {
+            window.sheetParent?.endSheet(window)
+        }
+    }
+    
+    @objc dynamic var fontSize: Double = UserDefaults.standard.double(forKey: .onelineFontSize) {
+        didSet {
+            UserDefaults.standard.set(fontSize, forKey: .onelineFontSize)
+        }
+    }
+}

--- a/DeveloperExcuses/DeveloperExcusesConfigureSheetWC.xib
+++ b/DeveloperExcuses/DeveloperExcusesConfigureSheetWC.xib
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="DeveloperExcusesConfigureSheetWC" customModule="DeveloperExcuses" customModuleProvider="target">
+            <connections>
+                <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
+            <windowStyleMask key="styleMask" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="196" y="240" width="177" height="103"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+            <view key="contentView" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="177" height="103"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i7D-G3-jnc">
+                        <rect key="frame" x="18" y="64" width="63" height="16"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Font size:" id="jgQ-71-6bO">
+                            <font key="font" usesAppearanceFont="YES"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lpa-B8-6a3">
+                        <rect key="frame" x="87" y="62" width="49" height="21"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="izy-BW-NF6">
+                            <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="W9F-2y-nnv"/>
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <binding destination="-2" name="value" keyPath="fontSize" id="BQf-xl-dHp"/>
+                        </connections>
+                    </textField>
+                    <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yMU-eT-0Kf">
+                        <rect key="frame" x="141" y="58" width="19" height="28"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <stepperCell key="cell" continuous="YES" alignment="left" maxValue="100" id="eYf-Yx-lM1"/>
+                        <connections>
+                            <binding destination="-2" name="value" keyPath="fontSize" id="dIx-7W-T5C"/>
+                        </connections>
+                    </stepper>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2oL-y9-aFi">
+                        <rect key="frame" x="81" y="13" width="82" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="OK" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Z8x-jN-gjO">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="endSheet:" target="-2" id="Gka-1k-Ck3"/>
+                        </connections>
+                    </button>
+                </subviews>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+            </connections>
+            <point key="canvasLocation" x="-12.5" y="63.5"/>
+        </window>
+    </objects>
+</document>

--- a/DeveloperExcuses/DeveloperExcusesView.swift
+++ b/DeveloperExcuses/DeveloperExcusesView.swift
@@ -1,4 +1,4 @@
-import Foundation
+import Cocoa
 import ScreenSaver
 
 private extension String {
@@ -24,5 +24,15 @@ class DeveloperExcusesView: OnelinerView {
         }
         
         completion(quotes.first!)
+    }
+    
+    override var hasConfigureSheet: Bool {
+        true
+    }
+    
+    var configureSheetWC = DeveloperExcusesConfigureSheetWC(windowNibName: "DeveloperExcusesConfigureSheetWC")
+    
+    override var configureSheet: NSWindow? {
+        configureSheetWC.window
     }
 }

--- a/DeveloperExcuses/Extension/String+Constants.swift
+++ b/DeveloperExcuses/Extension/String+Constants.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 extension String {
+    static let onelineFontSize = "onelineFontSize"
     static let lastOneline = "lastOneline"
     static let fetchQueue = "io.kida.OnelinerKit.fetchQueue"
 }

--- a/DeveloperExcuses/View/OnelinerView.swift
+++ b/DeveloperExcuses/View/OnelinerView.swift
@@ -68,8 +68,19 @@ open class OnelinerView: ScreenSaverView {
         preconditionFailure("`fetchOneline` must be overridden")
     }
     
+    open var onelineFontSize: Double {
+        let size = UserDefaults.standard.double(forKey: .onelineFontSize)
+        if size == 0 {
+            let defaultSize = 24.0
+            UserDefaults.standard.set(defaultSize, forKey: .onelineFontSize)
+            return defaultSize
+        } else {
+            return size
+        }
+    }
+    
     private func makeLabel(_ isPreview: Bool, bounds: CGRect) -> NSTextField {
-        let fontSize: CGFloat = 24.0
+        let fontSize = CGFloat(onelineFontSize)
         let label = NSTextField(frame: bounds)
         label.autoresizingMask = NSView.AutoresizingMask.width
         label.alignment = .center
@@ -79,7 +90,7 @@ open class OnelinerView: ScreenSaverView {
         if #available(OSX 10.15, *) {
             label.font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .medium)
         } else {
-            label.font = NSFont(name: "Courier", size: 24.0)
+            label.font = NSFont(name: "Courier", size: fontSize)
         }
         
         label.backgroundColor = .clear


### PR DESCRIPTION
To me, the old (13 pt) font size added a charming sense of humorous invalidity to the statements. But to each their own. To that end, I added a simple font size preference:

<img width="422" alt="Screen Shot 2020-04-10 at 4 02 53 PM" src="https://user-images.githubusercontent.com/16456186/79019718-f95f8200-7b44-11ea-972f-45af0c1cfac1.png">

The default is 24.  The only immediate hitch is that, for whatever reason, you have to click the "Screen Saver Options…" button twice for the configure sheet to show. I'm not sure why that is, but I don't really care to debug it. If it's a showstopper then you can close the PR, no harm done :)